### PR TITLE
Fix panic

### DIFF
--- a/logger/journald.go
+++ b/logger/journald.go
@@ -1,13 +1,13 @@
 package logger
 
 import (
-	"log"
 	"time"
 
 	"github.com/coreos/go-systemd/journal"
 	dockerLogger "github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/loggerutils"
 	cache "github.com/patrickmn/go-cache"
+	"github.com/segmentio/kit/log"
 )
 
 // JournaldLoggerFactory is a factory for creating journald loggers
@@ -52,7 +52,7 @@ func NewJournaldLogger(info dockerLogger.Info) *JournaldLogger {
 
 	tag, err := loggerutils.ParseLogTag(info, loggerutils.DefaultTemplate)
 	if err != nil {
-		log.Printf("logger: failed to parse logtag: %s", err)
+		log.Errorf("logger: failed to parse logtag: %s", err)
 		tag = info.ContainerID
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,9 +1,8 @@
 package logger
 
 import (
-	"log"
-
 	dockerLogger "github.com/docker/docker/daemon/logger"
+	"github.com/segmentio/kit/log"
 )
 
 // LoggerType specifies which type of downstream logger our handlers should

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type config struct {
 	SyslogAddress     string        `conf:"s" help:"Address to bind syslog server to (ex. udp://0.0.0.0:514)"`
 }
 
-//
+// DefaultConfig are the defaults for command line flags
 var DefaultConfig = config{
 	DockerHost:        "unix:///var/run/docker.sock",
 	RateLimitInterval: 5 * time.Second,


### PR DESCRIPTION
Older docker versions (1.12.6 in particular) use a different format for syslog tags.  This combined with a missing return statement caused a panic when I rolled out in stage.  This fixes that panic and also uses `kit/log` everywhere for logs (before it was a mix of `kit/log` and stdlib `log`.